### PR TITLE
Update main.rs - change Esperanto test to pandiacritical sentence

### DIFF
--- a/examples/test_text/main.rs
+++ b/examples/test_text/main.rs
@@ -53,7 +53,7 @@ Polski: Szybki brązowy lis skacze nad leniwym psem.
 
 🌈 Emoji: The 🦊quick brown f🐕x jumps over 🛌lazy animals 🎉 in different languages! 🌟
 
-Esperanto: La rapida bruna vulpo saltas super la laca hundo.
+Esperanto: Eĥoj ŝanĝas ĉiun ĵaŭdon.
 
 Italiano: La veloce volpe marrone salta sopra il cane pigro.
 


### PR DESCRIPTION
The test as stands is not useful for testing the ability to show Esperanto text. This commit changes it to instead read for Esperanto «Echoes change every thursday» («Eĥoj ŝanĝas ĉiun ĵaŭdon»), which is nonsense, but contains every diacritc in the Esperanto alphabet, unlike the sentence about fox jumping.

It might also be worthy to try to find and add similar pandiacritic or pangram sentences for other languages instead of using translations of the quick brown fox.